### PR TITLE
Initialize Terraform infrastructure skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,32 @@
 # BistroByte Infrastructure
 
-This repository contains infrastructure management code and configurations for the BistroByte project.
+This repository manages the infrastructure for the BistroByte restaurant management system using Terraform on AWS.
 
-## Overview
+## Structure
 
-The BistroByte infrastructure repository manages all cloud resources, deployment configurations, and infrastructure as code (IaC) needed to run BistroByte services.
+- `modules/` - Reusable Terraform modules
+  - `state/` - S3 bucket and DynamoDB table for Terraform state
+  - `ecr/` - Elastic Container Registry repositories
+- `state-setup/` - Deploys the Terraform state backend resources
+- `environments/` - Environment specific configurations
+  - `dev/`
+  - `prod/`
 
-## Purpose
+## Usage
 
-- Infrastructure as Code (IaC) management
-- Deployment configurations
-- Environment setup and maintenance
-- Resource provisioning
+1. **Initialize Terraform**
+   ```bash
+   terraform -chdir=state-setup init
+   ```
+2. **Apply state backend**
+   ```bash
+   terraform -chdir=state-setup apply
+   ```
+3. **Deploy an environment**
+   ```bash
+   terraform -chdir=environments/dev init
+   terraform -chdir=environments/dev apply
+   ```
+   Replace `dev` with `prod` for production.
 
-## Getting Started
-
-More details on setup and usage will be added as the project develops.
+These steps create the remote state storage and ECR repositories for each environment.

--- a/environments/dev/backend.tf
+++ b/environments/dev/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "bistrobyte-tf-state"
+    key            = "dev/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "bistrobyte-tf-lock"
+  }
+}

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+module "ecr" {
+  source           = "../../modules/ecr"
+  repository_name  = "bistrobyte-dev"
+}

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}

--- a/environments/prod/backend.tf
+++ b/environments/prod/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "bistrobyte-tf-state"
+    key            = "prod/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "bistrobyte-tf-lock"
+  }
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+module "ecr" {
+  source           = "../../modules/ecr"
+  repository_name  = "bistrobyte-prod"
+}

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,7 @@
+resource "aws_ecr_repository" "repo" {
+  name                 = var.repository_name
+  image_tag_mutability = "IMMUTABLE"
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,3 @@
+output "repository_url" {
+  value = aws_ecr_repository.repo.repository_url
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,4 @@
+variable "repository_name" {
+  description = "Name of the ECR repository"
+  type        = string
+}

--- a/modules/state/main.tf
+++ b/modules/state/main.tf
@@ -1,0 +1,20 @@
+resource "aws_s3_bucket" "state" {
+  bucket = var.bucket_name
+  versioning {
+    enabled = true
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_dynamodb_table" "lock" {
+  name         = var.dynamodb_table
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/modules/state/outputs.tf
+++ b/modules/state/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = aws_s3_bucket.state.id
+}
+
+output "dynamodb_table_name" {
+  value = aws_dynamodb_table.lock.name
+}

--- a/modules/state/variables.tf
+++ b/modules/state/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket to store terraform state"
+  type        = string
+}
+
+variable "dynamodb_table" {
+  description = "Name of the DynamoDB table for state locking"
+  type        = string
+}

--- a/state-setup/main.tf
+++ b/state-setup/main.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+module "state" {
+  source         = "../modules/state"
+  bucket_name    = var.bucket_name
+  dynamodb_table = var.dynamodb_table
+}

--- a/state-setup/outputs.tf
+++ b/state-setup/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = module.state.bucket_name
+}
+
+output "dynamodb_table_name" {
+  value = module.state.dynamodb_table_name
+}

--- a/state-setup/variables.tf
+++ b/state-setup/variables.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "bucket_name" {
+  description = "Name for the S3 bucket"
+  type        = string
+  default     = "bistrobyte-tf-state"
+}
+
+variable "dynamodb_table" {
+  description = "Name of DynamoDB table for locking"
+  type        = string
+  default     = "bistrobyte-tf-lock"
+}


### PR DESCRIPTION
## Summary
- set up reusable Terraform modules for state management and ECR
- create dev and prod environment definitions
- add state setup configuration
- document repository structure and usage